### PR TITLE
Register client CPT and taxonomy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Windows template
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+

--- a/admin/class-vvb-admin.php
+++ b/admin/class-vvb-admin.php
@@ -44,16 +44,25 @@ class Vvb_Admin {
 	 * Initialize the class and set its properties.
 	 *
 	 * @since    1.0.0
-	 * @param      string    $plugin_name       The name of this plugin.
-	 * @param      string    $version    The version of this plugin.
+	 *
+	 * @param      string $plugin_name The name of this plugin.
+	 * @param      string $version     The version of this plugin.
 	 */
 	public function __construct( $plugin_name, $version ) {
-
 		$this->plugin_name = $plugin_name;
-		$this->version = $version;
+		$this->version     = $version;
+		$this->init();
+	}
+
+	/**
+	 * Initialize the class.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	private function init() {
 		$this->register_cpt();
 		$this->register_taxonomy();
-
 	}
 
 	/**

--- a/admin/class-vvb-admin.php
+++ b/admin/class-vvb-admin.php
@@ -70,7 +70,7 @@ class Vvb_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public static function register_cpt() {
+	public function register_cpt() {
 
 		register_extended_post_type( 'client', array(
 
@@ -114,7 +114,7 @@ class Vvb_Admin {
 	 *
 	 * @since    1.0.0
 	 */
-	public static function register_taxonomy() {
+	public function register_taxonomy() {
 
 		register_extended_taxonomy( 'client_category', 'client', array(
 

--- a/admin/class-vvb-admin.php
+++ b/admin/class-vvb-admin.php
@@ -61,8 +61,8 @@ class Vvb_Admin {
 	 * @return void
 	 */
 	private function init() {
-		$this->register_cpt();
-		$this->register_taxonomy();
+		add_action( 'init', array( $this, 'register_cpt' ) );
+		add_action( 'init', array( $this, 'register_taxonomy' ) );
 	}
 
 	/**

--- a/admin/class-vvb-admin.php
+++ b/admin/class-vvb-admin.php
@@ -116,7 +116,7 @@ class Vvb_Admin {
 	 */
 	public static function register_taxonomy() {
 
-		register_extended_taxonomy( 'category', 'client', array(
+		register_extended_taxonomy( 'client_category', 'client', array(
 
 			# Show this taxonomy in the 'At a Glance' dashboard widget:
 			'dashboard_glance' => true,


### PR DESCRIPTION
Just a few quick improvements to avoid issues with CPT loading and prevent conflicts with WordPress' default `category` taxonomy.